### PR TITLE
fix bug resulting in the wrong node id when more than 9 nodes exist

### DIFF
--- a/tools/netedit/netedit.py
+++ b/tools/netedit/netedit.py
@@ -375,7 +375,7 @@ def on_menu_open_file():
         root.title(f"NetEdit - {current_filename}")
         selected_node = 0
         # get highest node number from graph.nodes
-        next_node_num = int(sorted(list(graph.nodes))[-1]) + 1
+        next_node_num = sorted([int(n) for n in graph.nodes])[-1] + 1
         update_ui()
 
 


### PR DESCRIPTION
graph.nodes returns a list of strings. sorting this leads to an alphabetic sort, i.e. ['1', '10', '11', '2', ...]. casting the node ids to int before sorting fixes this