### PR TITLE
Fix: Use default_factory for metadata in Message

### DIFF
--- a/pons/message.py
+++ b/pons/message.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import random
 
 
@@ -16,7 +16,7 @@ class Message(object):
     src_service: int = 0
     dst_service: int = 0
     content: dict = None
-    metadata = None
+    metadata: dict = field(default_factory=dict) 
 
     def __str__(self):
         return "Message(%s, src=%d.%d, dst=%d.%d, size=%d)" % (


### PR DESCRIPTION

- **Bug**:  Message dataclass was using a mutable default value for the metadata field, preventing the spray-and-wait router from adding messages correctly:
    - `ValueError: mutable default <class 'dict'> for field metadata is not allowed: use default_factory`
   
- **Fix**: The metadata field now uses `default_factory=dict` to ensure each Message instance receives its own independent dictionary.